### PR TITLE
Add recruiting platform modules

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -55,3 +55,5 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
       TF_VAR_postgres_admin_password: ${{ secrets.TF_VAR_POSTGRES_ADMIN_PASSWORD }}
       TF_VAR_strapi_admin_jwt_secret: ${{ secrets.TF_VAR_STRAPI_ADMIN_JWT_SECRET }}
+      TF_VAR_ghost_mail_username: ${{ secrets.TF_VAR_GHOST_MAIL_USERNAME }}
+      TF_VAR_ghost_mail_password: ${{ secrets.TF_VAR_GHOST_MAIL_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@
 ## Development
 
 Initialize terraform into correct environment by running `. ./init.sh <env>` where
-env is e.g. `prod`.
+env is e.g. `prod` (env name can contain only lowercase letters or numbers).
 
 Run `terraform plan` to see changes.

--- a/main.tf
+++ b/main.tf
@@ -39,3 +39,33 @@ module "cms" {
   postgres_admin_password = var.postgres_admin_password
   strapi_admin_jwt_secret = var.strapi_admin_jwt_secret
 }
+
+module "tikjob_storage" {
+  source                  = "./modules/recruiting/storage"
+  env_name                = terraform.workspace
+  resource_group_location = "northeurope"
+  ghost_db_username       = "tikrekryadmin"
+}
+
+module "tikjob_app" {
+  source = "./modules/recruiting/ghost"
+
+  env_name                = terraform.workspace
+  resource_group_name     = module.tikjob_storage.resource_group_name
+  resource_group_location = module.tikjob_storage.resource_group_location
+  ghost_front_url         = "https://rekry.tietokilta.fi"
+
+  mysql_db_name         = module.tikjob_storage.mysql_db_name
+  mysql_fqdn            = module.tikjob_storage.mysql_fqdn
+  mysql_connection_user = module.tikjob_storage.mysql_connection_user
+  mysql_password        = module.tikjob_storage.mysql_password
+
+  storage_account_name = module.tikjob_storage.storage_account_name
+  storage_account_key  = module.tikjob_storage.storage_account_key
+  storage_share_name   = module.tikjob_storage.storage_share_name
+
+  ghost_mail_host     = "smtp.eu.mailgun.org"
+  ghost_mail_port     = 465
+  ghost_mail_username = var.ghost_mail_username
+  ghost_mail_password = var.ghost_mail_password
+}

--- a/main.tf
+++ b/main.tf
@@ -55,10 +55,10 @@ module "tikjob_app" {
   resource_group_location = module.tikjob_storage.resource_group_location
   ghost_front_url         = "https://rekry.tietokilta.fi"
 
-  mysql_db_name         = module.tikjob_storage.mysql_db_name
-  mysql_fqdn            = module.tikjob_storage.mysql_fqdn
-  mysql_connection_user = module.tikjob_storage.mysql_connection_user
-  mysql_password        = module.tikjob_storage.mysql_password
+  mysql_db_name  = module.tikjob_storage.mysql_db_name
+  mysql_fqdn     = module.tikjob_storage.mysql_fqdn
+  mysql_username = module.tikjob_storage.mysql_username
+  mysql_password = module.tikjob_storage.mysql_password
 
   storage_account_name = module.tikjob_storage.storage_account_name
   storage_account_key  = module.tikjob_storage.storage_account_key

--- a/modules/recruiting/ghost/main.tf
+++ b/modules/recruiting/ghost/main.tf
@@ -1,0 +1,72 @@
+resource "azurerm_app_service_plan" "tikjob_plan" {
+  name                = "tikjob-${var.env_name}-plan"
+  location            = var.resource_group_location
+  resource_group_name = var.resource_group_name
+
+  kind     = "linux"
+  reserved = true # Needs to be true for linux
+
+  sku {
+    tier = "Basic"
+    size = "B1"
+  }
+}
+
+resource "azurerm_app_service" "tikjob_ghost" {
+  name                = "tikjob-${var.env_name}-app-ghost"
+  location            = var.resource_group_location
+  resource_group_name = var.resource_group_name
+  app_service_plan_id = azurerm_app_service_plan.tikjob_plan.id
+
+  https_only = true
+
+  site_config {
+    ftps_state       = "Disabled"
+    always_on        = true
+    linux_fx_version = "DOCKER|docker.io/library/ghost:4-alpine"
+  }
+
+  storage_account {
+    name         = "ghost-persistent-content-files"
+    type         = "AzureFiles"
+    account_name = var.storage_account_name
+    access_key   = var.storage_account_key
+    share_name   = var.storage_share_name
+    mount_path   = "/var/lib/ghost/content"
+  }
+
+  logs {
+    http_logs {
+      file_system {
+        retention_in_days = 7
+        retention_in_mb   = 100
+      }
+    }
+  }
+
+  app_settings = {
+    HOST = "0.0.0.0"
+    PORT = 2368
+
+    # GHOST CONFIGURATION
+    url = var.ghost_front_url
+
+    # Database
+    database__client                     = "mysql"
+    database__connection__host           = var.mysql_fqdn
+    database__connection__user           = var.mysql_connection_user
+    database__connection__password       = var.mysql_password
+    database__connection__database       = var.mysql_db_name
+    database__connection__ssl            = "true"
+    database__connection__ssl_minVersion = "TLSv1.2"
+
+    # Email
+    mail__transport           = "SMTP"
+    mail__options__service    = "Mailgun"
+    mail__options__host       = var.ghost_mail_host
+    mail__options__port       = var.ghost_mail_port
+    mail__options__secure     = "true"
+    mail__options__auth__user = var.ghost_mail_username
+    mail__options__auth__pass = var.ghost_mail_password
+  }
+}

--- a/modules/recruiting/ghost/main.tf
+++ b/modules/recruiting/ghost/main.tf
@@ -54,7 +54,7 @@ resource "azurerm_app_service" "tikjob_ghost" {
     # Database
     database__client                     = "mysql"
     database__connection__host           = var.mysql_fqdn
-    database__connection__user           = var.mysql_connection_user
+    database__connection__user           = var.mysql_username
     database__connection__password       = var.mysql_password
     database__connection__database       = var.mysql_db_name
     database__connection__ssl            = "true"

--- a/modules/recruiting/ghost/variables.tf
+++ b/modules/recruiting/ghost/variables.tf
@@ -15,7 +15,7 @@ variable "mysql_fqdn" {
   type = string
 }
 
-variable "mysql_connection_user" {
+variable "mysql_username" {
   type = string
 }
 

--- a/modules/recruiting/ghost/variables.tf
+++ b/modules/recruiting/ghost/variables.tf
@@ -1,0 +1,62 @@
+variable "env_name" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "resource_group_location" {
+  type = string
+}
+
+/* MySQL */
+variable "mysql_fqdn" {
+  type = string
+}
+
+variable "mysql_connection_user" {
+  type = string
+}
+
+variable "mysql_password" {
+  type = string
+}
+
+variable "mysql_db_name" {
+  type = string
+}
+
+/* Storage */
+variable "storage_account_name" {
+  type = string
+}
+
+variable "storage_account_key" {
+  type = string
+}
+
+variable "storage_share_name" {
+  type = string
+}
+
+/* Ghost */
+variable "ghost_mail_host" {
+  type = string
+}
+
+variable "ghost_mail_port" {
+  type = number
+}
+
+variable "ghost_mail_username" {
+  type = string
+}
+
+variable "ghost_mail_password" {
+  type = string
+}
+
+variable "ghost_front_url" {
+  type = string
+}

--- a/modules/recruiting/storage/main.tf
+++ b/modules/recruiting/storage/main.tf
@@ -1,0 +1,62 @@
+resource "azurerm_resource_group" "tikjob_rg" {
+  name     = "tikjob-${var.env_name}-rg"
+  location = var.resource_group_location
+}
+
+resource "random_password" "db_password" {
+  length           = 30
+  special          = true
+  override_special = "_%@"
+}
+
+resource "azurerm_mysql_server" "tikjob_mysql" {
+  name                = "tikjob-ghost-database"
+  location            = azurerm_resource_group.tikjob_rg.location
+  resource_group_name = azurerm_resource_group.tikjob_rg.name
+
+  administrator_login          = var.ghost_db_username
+  administrator_login_password = random_password.db_password.result
+
+  sku_name   = "B_Gen5_1"
+  storage_mb = 5120 #Max size in MB
+  version    = "5.7"
+
+  auto_grow_enabled                 = true
+  backup_retention_days             = 7
+  geo_redundant_backup_enabled      = false
+  infrastructure_encryption_enabled = false
+  public_network_access_enabled     = true
+  ssl_enforcement_enabled           = true
+  ssl_minimal_tls_version_enforced  = "TLS1_2"
+}
+
+resource "azurerm_mysql_database" "tikjob_mysql_db" {
+  name                = "ghost"
+  resource_group_name = azurerm_resource_group.tikjob_rg.name
+  server_name         = azurerm_mysql_server.tikjob_mysql.name
+  charset             = "utf8"
+  collation           = "utf8_unicode_ci"
+}
+
+# Enable access from other Azure services (TODO: Switch to IP list)
+resource "azurerm_mysql_firewall_rule" "tikjob_mysql_access" {
+  name                = "tikjob-${var.env_name}-mysql-access"
+  resource_group_name = azurerm_resource_group.tikjob_rg.name
+  server_name         = azurerm_mysql_server.tikjob_mysql.name
+  start_ip_address    = "0.0.0.0"
+  end_ip_address      = "0.0.0.0"
+}
+
+resource "azurerm_storage_account" "tikjob_storage_account" {
+  name                     = "tikjobpersistentcontent"
+  resource_group_name      = azurerm_resource_group.tikjob_rg.name
+  location                 = azurerm_resource_group.tikjob_rg.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_share" "tikjob_storage_share" {
+  name                 = "ghost-content"
+  storage_account_name = azurerm_storage_account.tikjob_storage_account.name
+  quota                = 5 # Max size in GB
+}

--- a/modules/recruiting/storage/main.tf
+++ b/modules/recruiting/storage/main.tf
@@ -10,7 +10,7 @@ resource "random_password" "db_password" {
 }
 
 resource "azurerm_mysql_server" "tikjob_mysql" {
-  name                = "tikjob-ghost-database"
+  name                = "tikjob-${var.env_name}-mysql-server"
   location            = azurerm_resource_group.tikjob_rg.location
   resource_group_name = azurerm_resource_group.tikjob_rg.name
 
@@ -31,7 +31,7 @@ resource "azurerm_mysql_server" "tikjob_mysql" {
 }
 
 resource "azurerm_mysql_database" "tikjob_mysql_db" {
-  name                = "ghost"
+  name                = "tikjob_${var.env_name}_ghost"
   resource_group_name = azurerm_resource_group.tikjob_rg.name
   server_name         = azurerm_mysql_server.tikjob_mysql.name
   charset             = "utf8"
@@ -48,7 +48,7 @@ resource "azurerm_mysql_firewall_rule" "tikjob_mysql_access" {
 }
 
 resource "azurerm_storage_account" "tikjob_storage_account" {
-  name                     = "tikjobpersistentcontent"
+  name                     = "tikjob${var.env_name}contents"
   resource_group_name      = azurerm_resource_group.tikjob_rg.name
   location                 = azurerm_resource_group.tikjob_rg.location
   account_tier             = "Standard"

--- a/modules/recruiting/storage/main.tf
+++ b/modules/recruiting/storage/main.tf
@@ -48,7 +48,7 @@ resource "azurerm_mysql_firewall_rule" "tikjob_mysql_access" {
 }
 
 resource "azurerm_storage_account" "tikjob_storage_account" {
-  name                     = "tikjob${var.env_name}contents"
+  name                     = "tikjob${var.env_name}contentsa"
   resource_group_name      = azurerm_resource_group.tikjob_rg.name
   location                 = azurerm_resource_group.tikjob_rg.location
   account_tier             = "Standard"

--- a/modules/recruiting/storage/output.tf
+++ b/modules/recruiting/storage/output.tf
@@ -11,7 +11,7 @@ output "mysql_fqdn" {
   value = azurerm_mysql_server.tikjob_mysql.fqdn
 }
 
-output "mysql_connection_user" {
+output "mysql_username" {
   value = "${azurerm_mysql_server.tikjob_mysql.administrator_login}@${azurerm_mysql_server.tikjob_mysql.name}"
 }
 

--- a/modules/recruiting/storage/output.tf
+++ b/modules/recruiting/storage/output.tf
@@ -1,0 +1,39 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.tikjob_rg.name
+}
+
+output "resource_group_location" {
+  value = azurerm_resource_group.tikjob_rg.location
+}
+
+/* MySQL */
+output "mysql_fqdn" {
+  value = azurerm_mysql_server.tikjob_mysql.fqdn
+}
+
+output "mysql_connection_user" {
+  value = "${azurerm_mysql_server.tikjob_mysql.administrator_login}@${azurerm_mysql_server.tikjob_mysql.name}"
+}
+
+output "mysql_password" {
+  value     = azurerm_mysql_server.tikjob_mysql.administrator_login_password
+  sensitive = true
+}
+
+/* Storage */
+output "storage_account_name" {
+  value = azurerm_storage_account.tikjob_storage_account.name
+}
+
+output "storage_account_key" {
+  value     = azurerm_storage_account.tikjob_storage_account.primary_access_key
+  sensitive = true
+}
+
+output "storage_share_name" {
+  value = azurerm_storage_share.tikjob_storage_share.name
+}
+
+output "mysql_db_name" {
+  value = azurerm_mysql_database.tikjob_mysql_db.name
+}

--- a/modules/recruiting/storage/variables.tf
+++ b/modules/recruiting/storage/variables.tf
@@ -1,0 +1,11 @@
+variable "env_name" {
+  type = string
+}
+
+variable "resource_group_location" {
+  type = string
+}
+
+variable "ghost_db_username" {
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,5 +3,15 @@ variable "postgres_admin_password" {
 }
 
 variable "strapi_admin_jwt_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "ghost_mail_username" {
   type = string
+}
+
+variable "ghost_mail_password" {
+  type      = string
+  sensitive = true
 }


### PR DESCRIPTION
Add two new modules that create the Ghost based recruitment platform and its persistent storage resources. See readme at [https://github.com/htunk/tikrekry-infra/blob/master/README.md](https://github.com/htunk/tikrekry-infra/blob/master/README.md) for quick explanation on the new TF variables regarding Ghost.

**What has been done**:
- Add two new modules
- Add two new TF variables for Ghost SMTP credentials to Github secrets
- Update Github workflow
- Tested the two modules using terraform apply with -target param

**What needs to be done**:
- Code review pls ":D"
- Add CNAME to rekry.tietokilta.fi to match the app service url
- Release changes to Azure if merged