### PR TITLE
Stop init.sh from leaking state access keys

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -29,18 +29,23 @@ esac
 
 SUBSCRIPTION=$(az account show --query 'id' --output tsv --subscription "$SUBSCRIPTION_NAME")
 echo "Activating subscription: $SUBSCRIPTION ($SUBSCRIPTION_NAME)"
-az account set --subscription $SUBSCRIPTION
-TF_STATE_STORAGE_ACCOUNT_KEY=$(az storage account keys list --account-name $TFSTATE_STORAGE_ACCOUNT_NAME --resource-group $TFSTATE_STORAGE_RESOURCE_GROUP_NAME --subscription $SUBSCRIPTION --query "[?keyName=='key1'].value" --output tsv)
+az account set --subscription "$SUBSCRIPTION"
+TFSTATE_STORAGE_ACCOUNT_KEY=$(az storage account keys list --account-name "$TFSTATE_STORAGE_ACCOUNT_NAME" --resource-group "$TFSTATE_STORAGE_RESOURCE_GROUP_NAME" --subscription "$SUBSCRIPTION" --query "[?keyName=='key1'].value" --output tsv)
+
+cat >> config.azurerm.tfbackend << EOF
+storage_account_name = "$TFSTATE_STORAGE_ACCOUNT_NAME"
+access_key           = "$TFSTATE_STORAGE_ACCOUNT_KEY"
+EOF
 
 echo "Initializing terraform"
-terraform init -backend-config="storage_account_name=$TFSTATE_STORAGE_ACCOUNT_NAME" -backend-config="access_key=$TF_STATE_STORAGE_ACCOUNT_KEY"
+terraform init -backend-config=config.azurerm.tfbackend
 
 TF_WORKSPACES=$(terraform workspace list)
-if [[ $TF_WORKSPACES =~ $WORKSPACE ]]
+if [[ "$TF_WORKSPACES" =~ "$WORKSPACE" ]]
 then
   echo "Switching to workspace ${WORKSPACE}"
-  terraform workspace select $WORKSPACE
+  terraform workspace select "$WORKSPACE"
 else
   echo "Workspace does not exist, creating"
-  terraform workspace new $WORKSPACE
+  terraform workspace new "$WORKSPACE"
 fi


### PR DESCRIPTION
The current `init.sh` is showing the access key in the logs for whatever stupid reason. This ought to fix it by hiding the sensitive stuff in a file.